### PR TITLE
fix(boiler): reset pump running time to zero at timestep ends

### DIFF
--- a/src/core/heating_systems/boiler.rs
+++ b/src/core/heating_systems/boiler.rs
@@ -1232,6 +1232,7 @@ impl Boiler {
         self.calc_auxiliary_energy(time_remaining_current_timestep, simtime.index);
 
         self.total_time_running_current_timestep = Default::default();
+        self.pump_running_time_current_timestep = Default::default();
         self.service_results = Default::default();
 
         Ok(())


### PR DESCRIPTION
Added one missing line to `Boiler::timestep_end` such that the cumulative running-time counter for circulator-pump is properly reset at the end of each timestep during the core simulation loop.

In the upstream Python design `src/hem_core/heating_systems/boiler.py` line 1061, `self.__pump_running_time_current_timestep` is reset back to 0 at timestep ends. This line is missing from `Boiler::timestep_end` in `src/core/heating_systems/boiler.rs` of the Rust implementation, which is supposed to mirror the former Python design.

Caught a nasty one when testing our downstream heat models.  Got an unexpected 2.3 million kWh/yr in electricity usage in my results which trace me back to this line. Hope this helps!